### PR TITLE
feat(test): add unit test for hash-object command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,24 @@ You will implement a subset of Git commands, both low-level (plumbing) and user-
 
 ## 🛠 Plumbing Commands
 
-### `git hash-object <file>`
+### `git hash-object [-w] <file>`
+
 - **Creates a blob** object from file content and writes its SHA-1 to stdout.
 - ❌ Reject directories or missing files.
 
 ### `git cat-file -t|-p <oid>`
+
 - `-t`: Print object type.
 - `-p`: Pretty-print blob/tree/commit content.
 - ❌ Reject invalid OIDs or missing options.
 
 ### `git write-tree`
+
 - Create a tree object from the staging area.
 - Writes SHA-1 of the tree to stdout.
 
 ### `git commit-tree <tree_sha> -m "msg" [-p <parent>]`
+
 - Creates a commit object pointing to a tree (and parent commit if any) and writes its oid to stdout
 - Requires `-m` message.
 - ❌ No annotated tags.
@@ -33,48 +37,60 @@ You will implement a subset of Git commands, both low-level (plumbing) and user-
 ## 🧑‍💻 Porcelain Commands
 
 ### `git init [<dir>]`
+
 - Initializes a Git repository in the given directory.
 - Create .git/objects, .git/refs/heads, HEAD, and minimal config
 
 ### `git add <file>…`
+
 - Adds files to the staging area (not directories).
 - ❌ No `-p`, no wildcards.
 
 ### `git rm <file>…`
+
 - Removes a file from working directory and index.
 
 ### `git commit -m "msg"`
+
 - Runs `write-tree`, creates a commit with HEAD as parent.
 - ❌ No editor or message prompt.
 
 ### `git status`
+
 - Shows staged and unstaged changes.
 
 ### `git checkout [-b] <branch|sha>`
+
 - Switch to existing commit or branch.
 - `-b <branch>` creates a new branch.
 - Change HEAD, update working dir, check for conflicts
 
 ### `git reset [--soft|--mixed|--hard] <sha>`
+
 - `--soft`: move HEAD
 - `--mixed`: + reset index
 - `--hard`: + reset working directory
 - ❌ No file-specific reset.
 
 ### `git log`
+
 - Print commit history from HEAD (one-line summary ok).
 
 ### `git ls-files`
+
 - List all files in the index.
 
 ### `git ls-tree <tree_sha>`
+
 - List contents of a tree object.
 
 ### `git rev-parse <ref>`
+
 - Convert ref/branch/HEAD into SHA-1.
 - ❌ No complex selectors
 
 ### `git show-ref`
+
 - List all refs and their hashes.
 
 ---
@@ -82,6 +98,7 @@ You will implement a subset of Git commands, both low-level (plumbing) and user-
 ## 🧠 Advanced Feature: Merge Support
 
 ### `git merge <branch|sha>`
+
 - Perform 3-way merge and create a merge commit with 2 parents.
 - On conflict: insert `<<<<<<<`, `=======`, `>>>>>>>` markers into file(s).
 - ❌ No rebase, squash, or fast-forward-only merges.

--- a/git_scratch/commands/hash_object.py
+++ b/git_scratch/commands/hash_object.py
@@ -3,9 +3,6 @@ import os
 import zlib
 import typer
 
-app = typer.Typer()
-
-# @app.command("hash-object")
 def hash_object(
     file_path: str = typer.Argument(..., help="Path to the file to hash."),
     write: bool = typer.Option(False, "--write", "-w", help="Store object in .git/objects.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ dependencies = [
     "typer[all]",
 ]
 
+[project.optional-dependencies]
+dev = ["pytest"]
+
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"

--- a/tests/unit/test_hash_object.py
+++ b/tests/unit/test_hash_object.py
@@ -1,0 +1,58 @@
+
+import subprocess
+from git_scratch.main import app
+from typer.testing import CliRunner
+import zlib
+import os
+
+runner = CliRunner()
+
+def test_hash_object_matches_git_and_writes_blob(tmp_path):
+    file = tmp_path / "test.txt"
+    content = "Hello Git Scratch"
+    file.write_text(content)
+
+    # Initialiser un dépôt Git dans tmp_path
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True)
+
+    # 1. Comparaison du hash sans --write
+    result_git = subprocess.run(
+        ["git", "hash-object", str(file)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    hash_git = result_git.stdout.strip()
+
+    # 🔧 On change manuellement le dossier courant
+    current_dir = os.getcwd()
+    os.chdir(tmp_path)
+
+    try:
+        result_pit = runner.invoke(app, ["hash-object", str(file.name)])
+        assert result_pit.exit_code == 0
+        hash_pit = result_pit.stdout.strip()
+        print("Hash Git : ",hash_git, " Hash Pit : ",hash_pit)
+        assert hash_pit == hash_git, "Le hash généré par pit ne correspond pas à celui de Git"
+
+        # 2. Avec l’option --write
+        result_write = runner.invoke(app, ["hash-object", str(file.name), "--write"])
+        assert result_write.exit_code == 0
+        hash_written = result_write.stdout.strip()
+
+        obj_dir = tmp_path / ".git" / "objects" / hash_written[:2]
+        obj_file = obj_dir / hash_written[2:]
+        assert obj_file.exists(), f"Le blob compressé {obj_file} n'a pas été écrit"
+
+        with open(obj_file, "rb") as f:
+            compressed_data = f.read()
+        full_data = zlib.decompress(compressed_data)
+
+        expected_header = f"blob {len(content)}\0".encode()
+        expected_blob = expected_header + content.encode()
+        assert full_data == expected_blob, "Le contenu du blob est incorrect"
+    
+    finally:
+        os.chdir(current_dir)  # On revient dans le dossier original à la fin
+


### PR DESCRIPTION
### Changes
- Updating the README.md with the lateset versions.
- Removing useless code lines from the hash-object command.
- Adding pytest to the dev dependencies.
- Adding the unit test for the command hash-object in tests/unit

Closes #1  